### PR TITLE
[-] mondialrelay : fix preSelectedRelay to -1 instead of 0

### DIFF
--- a/mondialrelay.php
+++ b/mondialrelay.php
@@ -672,7 +672,7 @@ class MondialRelay extends Module
 				'carrier_list' => $carriersList,
 				'carrier' => $carrier,				
 				'PS_VERSION' => _PS_VERSION_,
-				'pre_selected_relay' => isset($preSelectedRelay['MR_selected_num']) ? $preSelectedRelay['MR_selected_num'] : 0,
+				'pre_selected_relay' => isset($preSelectedRelay['MR_selected_num']) ? $preSelectedRelay['MR_selected_num'] : -1,
 			))
 		));
 		if (Configuration::get('MONDIAL_RELAY_MODE') == 'widget')


### PR DESCRIPTION
Hi,
$preSelectedRelay['MR_selected_num'] is always set to 0 in the mondialrelay.php file, making it impossible to change relay selection,
i propose that correction by replacing it with the value -1.
Thanks.
Satoru HEMMI
202-ecommerce