### PR TITLE
Fixed no alert display when no relay point selected

### DIFF
--- a/js/mondialrelay.js
+++ b/js/mondialrelay.js
@@ -605,6 +605,12 @@ var PS_MRObject = (function($, undefined) {
 			alert(PS_MRTranslationList['errorSelection']);
 			return false;
 		}
+		// No relay point selected yet
+		if (PS_MRSelectedRelayPoint['relayPointNum'] == -1)
+		{
+			alert(PS_MRTranslationList['errorSelection']);
+			return false;
+		}
 		return true;
 	}
 


### PR DESCRIPTION
User had possibility to continue to payment page even without relay point selected
(I think it was introduced by commit f6c3c8c13e7506ca9c350d03da65cc4b3e25d578, due to change of not selected value from 0 to -1)